### PR TITLE
PropertyGrid: Fix custom editor support

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyResolver.cs
@@ -116,7 +116,7 @@ namespace HandyControl.Controls
                     : new ReadOnlyTextPropertyEditor();
         }
 
-        public virtual PropertyEditorBase CreateEditor(Type type) => new ReadOnlyTextPropertyEditor();
+        public virtual PropertyEditorBase CreateEditor(Type type) => Activator.CreateInstance(type) as PropertyEditorBase ?? new ReadOnlyTextPropertyEditor();
 
         public static bool IsKnownEditorType(Type type)
         {


### PR DESCRIPTION
Custom editors were not created for unknown property types but only the default editor.